### PR TITLE
fix bss node reporting bugs

### DIFF
--- a/+meegpipe/+node/+bss/@bss/make_bss_object_report.m
+++ b/+meegpipe/+node/+bss/@bss/make_bss_object_report.m
@@ -22,7 +22,7 @@ generate(objRep);
 fprintf(rep, 'BSS performed using algorithm [%s](%s)\n\n', class(myBSS), ...
     [repName '.htm']);
 
-set_method_config(myBSS, 'fprintf', 'ParseDisp', false, 'SaveBinary', true);
+myBSS = set_method_config(myBSS, 'fprintf', 'ParseDisp', false, 'SaveBinary', true);
 fprintf(rep, myBSS);
 
 end

--- a/+meegpipe/+node/+bss/@bss/make_explained_var_report.m
+++ b/+meegpipe/+node/+bss/@bss/make_explained_var_report.m
@@ -133,14 +133,16 @@ for i = 1:numel(sensorArray),
             for k = 1:size(A,2)
                 stat = bpVarStats(statNames{j});
                 statVal(k, j) = stat(A(sensorIdx{i},k));
-                yMin = min(yMin, statVal(k, j));
-                yMax = max(yMax, statVal(k, j));
+%                 yMin = min(yMin, statVal(k, j));
+%                 yMax = max(yMax, statVal(k, j));
             end
             hold on;
             plot(statVal(:,j), rnd_line_format(j));
             text(pos(1+j), statVal(pos(1+j),j), statNames{j}, ...
                 'FontSize', 10, 'BackgroundColor', 'white', 'FontWeight', 'bold');
         end
+        yMax = max([yMax; statVal(isfinite(statVal))]);
+        yMin = min([yMin; statVal(isfinite(statVal))]);
         R = (yMax - yMin);
         axis([0.75 numel(maxAbsVar)+0.25 yMin-0.05*abs(R) yMax+0.05*R]);
     end


### PR DESCRIPTION
I encountered some bugs during my BSS runs. First is that the projection matrix was not saved. Second is that sometimes the infinite values of log explained variances (when the component back projection is zero) would crash the report generator. I did some fixes for these two bugs. The fixes were tested and the BSS node should work fine now.